### PR TITLE
M1: Add standardization files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+.PHONY: setup lint typecheck test dev build clean
+
+# Setup project
+setup:
+	npm install
+	cp -n .env.example .env || true
+	@echo "✓ Setup complete. Edit .env with your credentials."
+
+# Code quality
+lint:
+	npm run lint 2>/dev/null || echo "No lint script"
+
+typecheck:
+	npm run check-types 2>/dev/null || npx tsc --noEmit
+
+# Testing
+test:
+	@echo "⚠️  No tests configured"
+
+# Development
+dev:
+	npm start
+
+# Build
+build:
+	npm run build 2>/dev/null || npx tsc
+
+# Clean
+clean:
+	rm -rf node_modules dist
+
+help:
+	@echo "Targets: setup lint typecheck test dev build clean"

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,59 @@
+# image_mcp_server Runbook
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| Name | image_mcp_server |
+| Type | MCP Server |
+| Runtime | Node.js 22 |
+| Protocol | MCP over HTTP |
+| Port | 3000 (default) |
+
+## Quick Commands
+
+```bash
+make setup      # Install deps, create .env
+make dev        # Start server
+make build      # Build TypeScript
+make typecheck  # Type check
+```
+
+## Health Check
+
+```bash
+curl -X POST http://localhost:3000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
+```
+
+## Local Development
+
+```bash
+make setup
+# Edit .env with credentials
+make dev
+```
+
+## Environment Variables
+
+See `.env.example` for required variables.
+
+## Common Issues
+
+### Connection Refused
+- Check server is running on correct port
+- Verify PORT env var
+
+### Auth Failed
+- Check API credentials in .env
+- Verify OAuth tokens are valid
+
+## Deployment
+
+```bash
+make build
+npm start
+```
+
+Or via Docker if Dockerfile exists.


### PR DESCRIPTION
## Summary
- Added Makefile with standard targets (setup, lint, typecheck, test, dev, build)
- Added docs/RUNBOOK.md with operational documentation
- Updated/verified .env.example

## Files Added
- `Makefile` - Standard build targets
- `docs/RUNBOOK.md` - Operational runbook

## Note
CI workflow (.github/workflows/ci.yml) to be added separately (requires workflow scope).

---
🤖 Generated with [Claude Code](https://claude.ai/code)